### PR TITLE
Fix: distutils not found in v0.2.13 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.11-alpine
 
 COPY ./nginx/entrypoint.py /entrypoint.py
 RUN \


### PR DESCRIPTION
Uses `python:3.11-alpine` base image, which contains otumat dependency distutils, instead of `python:alpine`, which currently points to `python:3.12-alpine` without distutils installed.

### Steps to Reproduce

<details><summary>Details</summary>
<p>

On c06a6fc:

```console
❯ TAG=foo docker compose up --build         
WARN[0000] /home/eho/repos/dj/nginx-docker/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Building 0.3s (11/11) FINISHED                                                        docker:default
 => [fakeservices.datajoint.io internal] load build definition from Dockerfile                      0.0s
 => => transferring dockerfile: 904B                                                                0.0s
 => [fakeservices.datajoint.io internal] load metadata for docker.io/library/python:alpine          0.2s
 => [fakeservices.datajoint.io internal] load .dockerignore                                         0.0s
 => => transferring context: 2B                                                                     0.0s
 => [fakeservices.datajoint.io 1/5] FROM docker.io/library/python:alpine@sha256:7130f75b1bb16c7c5d  0.0s
 => [fakeservices.datajoint.io internal] load build context                                         0.0s
 => => transferring context: 142B                                                                   0.0s
 => CACHED [fakeservices.datajoint.io 2/5] COPY ./nginx/entrypoint.py /entrypoint.py                0.0s
 => CACHED [fakeservices.datajoint.io 3/5] RUN     apk update &&     apk add openssl nginx nginx-m  0.0s
 => CACHED [fakeservices.datajoint.io 4/5] COPY ./nginx/privkey.pem /etc/letsencrypt/live/fakeserv  0.0s
 => CACHED [fakeservices.datajoint.io 5/5] COPY ./nginx/fullchain.pem /etc/letsencrypt/live/fakese  0.0s
 => [fakeservices.datajoint.io] exporting to image                                                  0.0s
 => => exporting layers                                                                             0.0s
 => => writing image sha256:b55e85f381e49145027db680e9f6f7e451780ce26328bbadf38a19a10c6589a9        0.0s
 => => naming to docker.io/datajoint/nginx:foo                                                      0.0s
 => [fakeservices.datajoint.io] resolving provenance for metadata file                              0.0s
[+] Running 1/1
 ✔ Container nginx-docker-fakeservices.datajoint.io-1  Recreated                                    0.0s 
Attaching to fakeservices.datajoint.io-1
fakeservices.datajoint.io-1  | Traceback (most recent call last):
fakeservices.datajoint.io-1  |   File "/entrypoint.py", line 9, in <module>
fakeservices.datajoint.io-1  |     import otumat.watch
fakeservices.datajoint.io-1  |   File "/usr/local/lib/python3.12/site-packages/otumat/__init__.py", line 4, in <module>
fakeservices.datajoint.io-1  |     import distutils.errors
fakeservices.datajoint.io-1  | ModuleNotFoundError: No module named 'distutils'
fakeservices.datajoint.io-1 exited with code 1
```

Propagating to `datajoint-python` CI runs such as: https://github.com/datajoint/datajoint-python/actions/runs/10983009694/job/30491922895?pr=1188

</p>
</details> 